### PR TITLE
Make app runnable and docker-ready

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+npm-debug.log
+Dockerfile
+.dockerignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+api/node_modules
+.env
+api/package-lock.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY api/package*.json ./api/
+RUN cd api && npm ci --only=production
+COPY api /app/api
+VOLUME ["/data"]
+EXPOSE 3000
+CMD ["node", "api/server.js"]

--- a/api/server.js
+++ b/api/server.js
@@ -6,6 +6,8 @@ import jwt from 'jsonwebtoken'
 import bcrypt from 'bcryptjs'
 import Database from 'better-sqlite3'
 import crypto from 'crypto'
+import fs from 'fs'
+import path from 'path'
 
 const app = express()
 app.use(express.json({ limit: '1mb' }))
@@ -17,6 +19,9 @@ app.use(cookieParser())
 // JWT/Cookie-Settings
 // ------------------------------------------------------------------
 const JWT_SECRET = process.env.JWT_SECRET || 'dev_insecure_change_me'
+if (JWT_SECRET === 'dev_insecure_change_me') {
+  console.warn('Warning: using insecure default JWT secret; set JWT_SECRET in production')
+}
 const COOKIE_NAME = 'ff_token'
 const COOKIE_SECURE = String(process.env.COOKIE_SECURE || '') === 'true' // bei HTTPS → true
 const COOKIE_DOMAIN = process.env.COOKIE_DOMAIN || undefined
@@ -36,7 +41,9 @@ function issueCookie(res, userId) {
 // ------------------------------------------------------------------
 // DB & Migration
 // ------------------------------------------------------------------
-const db = new Database('/data/focusflow.sqlite')
+const DB_PATH = process.env.DB_PATH || '/data/focusflow.sqlite'
+fs.mkdirSync(path.dirname(DB_PATH), { recursive: true })
+const db = new Database(DB_PATH)
 db.pragma('journal_mode = WAL')
 
 // Users


### PR DESCRIPTION
## Summary
- ensure SQLite storage path is configurable and always exists
- warn when insecure JWT secret is used
- add Dockerfile and ignore files for container builds

## Testing
- `node api/server.js &`
- `curl -s localhost:3000/health`
- `docker build -t focusflow-test .` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6899c0f5e2e8832693aa34fea6a095a3